### PR TITLE
api: add /test for testing ip reachability

### DIFF
--- a/api/error.go
+++ b/api/error.go
@@ -1,12 +1,27 @@
 package api
 
-import "net/http"
+import (
+	"errors"
+	"net/http"
+)
+
+var (
+	errBadRequest = newAppError(http.StatusBadRequest)
+	errGone       = newAppError(http.StatusGone)
+)
 
 type appError struct {
 	Error       error
 	Response    string
 	Code        int
 	ContentType string
+}
+
+func newAppError(code int) *appError {
+	return &appError{
+		Error: errors.New(http.StatusText(code)),
+		Code:  code,
+	}
 }
 
 func internalServerError(err error) *appError {

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ func main() {
 		Listen        string `short:"l" long:"listen" description:"Listening address" value-name:"ADDR" default:":8080"`
 		CORS          bool   `short:"x" long:"cors" description:"Allow requests from other domains"`
 		ReverseLookup bool   `short:"r" long:"reverselookup" description:"Perform reverse hostname lookups"`
+		TestIP        bool   `short:"s" long:"testip" description:"Enable IP reachability testing"`
 		Template      string `short:"t" long:"template" description:"Path to template" default:"index.html"`
 	}
 	_, err := flags.ParseArgs(&opts, os.Args)
@@ -35,6 +36,7 @@ func main() {
 	a.CORS = opts.CORS
 	a.ReverseLookup = opts.ReverseLookup
 	a.Template = opts.Template
+	a.TestIP = opts.TestIP
 
 	log.Printf("Listening on %s", opts.Listen)
 	if err := a.ListenAndServe(opts.Listen); err != nil {


### PR DESCRIPTION
Hey @martinp!

I was wondering whether it would be useful for `ifconfig.co` to test whether user IPs are reachable from the internet (e.g. those behind NAT).

This PR adds /test method for testing the reachability, which returns:

- `400` on wrong input
- `410` when IP is not reachable
- `200` when it is

Usage:

```bash
$ curl -v rjk.io/test/89.67.178.12 # or ifconfig.co/test/89.67.178.12
*   Trying 104.197.132.232...
* Connected to rjk.io (104.197.132.232) port 80 (#0)
> GET /test/89.67.178.12 HTTP/1.1
> Host: rjk.io
> User-Agent: curl/7.43.0
> Accept: */*
> 
< HTTP/1.1 410 Gone
< Content-Type: text/plain; charset=utf-8
< Date: Thu, 03 Mar 2016 15:29:34 GMT
```

What do you think?