### PR TITLE
Add support for PowerShell's Invoke-WebRequest

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -25,7 +25,16 @@ const (
 )
 
 var userAgentPattern = regexp.MustCompile(
-	`^(?:curl|Wget|fetch\slibfetch|ddclient|Go-http-client|HTTPie)\/.*|Go\s1\.1\spackage\shttp$`,
+	`^` +
+	`curl` +
+	`|Wget` +
+	`|fetch\slibfetch` +
+	`|ddclient` +
+	`|HTTPie` +
+	`|Go-http-client` +
+	`|Go\s\d\.\d\spackage\shttp` +
+	`|Mozilla/\d\.\d.*WindowsPowerShell/(\d+\.\d+)?` +
+	`.*$`,
 )
 
 type API struct {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -156,6 +156,9 @@ func TestCLIMatcher(t *testing.T) {
 		{"Go-http-client/1.1", true},
 		{"Go-http-client/2.0", true},
 		{"ddclient/3.8.3", true},
+		{"Mozilla/5.0 (Windows NT; Windows NT 6.1; en-US) WindowsPowerShell/3.0", true},
+		{"Mozilla/5.0 (Windows NT; Windows NT 6.2; en-US) WindowsPowerShell/4.0", true},
+		{"Mozilla/5.0 (Windows NT; Darwin 16.4.0 Darwin Kernel Version 16.4.0: Thu Dec 22 22:53:21 PST 2016; root:xnu-3789.41.3~3/RELEASE_X86_64; en-US) WindowsPowerShell/6.0.0", true},
 		{browserUserAgent, false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
* This commit adds CLI support for Windows PowerShell's
Invoke-WebRequest and similar cmdlets.
* Due to how complex the Regular Expression for CLI matching was
getting, this also slightly refactors how the regular expression string
is handled, breaking the OR'd parts across multiple lines.
* There is also a change to the Go client(s) regex, to make it survive
future Golang version updates.
* The matching style for the Golang UAs is cleaned up to be easier to
read (each on it's own line)
* Test cases added for PowerShell on two versions of Windows, and OSX
via the latest version. All previous + new test cases pass as expected.